### PR TITLE
chore: drop the effectively deprecated author meta field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "logcall"
 version = "0.1.10"
 edition = "2021"
-authors = ["FastLabs Developers"]
 description = "An attribute macro that logs the function return value."
 repository = "https://github.com/fast/logcall"
 documentation = "https://docs.rs/logcall"


### PR DESCRIPTION
For simplicity.